### PR TITLE
routes の tag に関数を指定できるよう修正

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -55,7 +55,10 @@ spat.start = () => {
 };
 
 spat.goto = async (route, req, res) => {
-  await spat.appTag.gotoPage(route.tag, req, res);
+  await spat.appTag.gotoPage(route, req, res);
+
+  spat.appTag.pageTag.trigger('show');
+  spat.appTag.pageTag.update();
 
   // meta の設定
   var titleElement = document.querySelector('title');

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -135,11 +135,15 @@ class Router {
     };
     // レスポンスオブジェクトを作成
     var res = {
-      redirect: (status, url) => {
+      status: function(status) {
+        this.statusCode = status;
+      },
+      redirect: function(status, url) {
         if (typeof status === 'string') {
           url = status;
           status = 302;
         }
+        this.status(status);
         this.replace(url);
       }
     };

--- a/src/server.mjs
+++ b/src/server.mjs
@@ -80,10 +80,11 @@ Object.keys(routes).forEach(key => {
   app.get(key, async (req, res, next) => {
     var route = routes[key];
 
-    var ssr = new Ssriot(route.tag);
+    var ssr = new Ssriot();
     await ssr.render({
       req,
       res,
+      route,
       isSsr: (route.ssr !== undefined) ? route.ssr : config.server.ssr
     });
 
@@ -124,9 +125,15 @@ app.use(async (req, res, next) => {
 
   res.status(404);
 
-  var ssr = new Ssriot('page-error');
+  var ssr = new Ssriot();
+  var route = {
+    tag: 'page-error',
+  };
   await ssr.render({
-    req, res
+    req,
+    res,
+    route,
+    isSsr: (route.ssr !== undefined) ? route.ssr : config.server.ssr
   });
 
   // 描画

--- a/src/ssriot.js
+++ b/src/ssriot.js
@@ -7,11 +7,10 @@ const fetch = require('node-fetch');
 global.fetch = fetch;
 
 module.exports = class Ssriot {
-  constructor(tagName) {
-    this.tagName = tagName;
+  constructor() {
   }
 
-  async render({req, res, isSsr}) {
+  async render({req, res, route, isSsr}) {
     var element = document.createElement('div');
     element.setAttribute('render', 'server');
     element.setAttribute('data-is', 'spat-app');
@@ -19,7 +18,7 @@ module.exports = class Ssriot {
     this.tag = riot.mount(element)[0];
 
     if (isSsr) {
-      await this.tag.gotoPage(this.tagName, req, res);
+      await this.tag.gotoPage(route, req, res);
     }
     else {
       this.tag.head = spat.config.head;

--- a/src/tags/spat-app.pug
+++ b/src/tags/spat-app.pug
@@ -22,7 +22,16 @@ spat-app
 
     var sleep = (msec) => new Promise(resolve => setTimeout(resolve, msec));
 
-    this.gotoPage = async (tagName, req, res) => {
+    this.gotoPage = async (route, req, res) => {
+      // route からタグ名を取得
+      var tagName = '';
+      if (typeof route.tag === 'function') {
+        tagName = await route.tag({req, res})
+      }
+      else {
+        tagName = route.tag;
+      }
+
       this.refs.pages.innerHTML = '';
       
       var element = document.createElement('div');
@@ -36,13 +45,6 @@ spat-app
 
       // head 取得
       this.head = this.getHead(pageTag);
-
-      // TODO: ちゃんと他も反映されるように作り込む
-
-      if (spat.isBrowser) {
-        pageTag.trigger('show');
-        pageTag.update();
-      }
 
       this.pageTag = pageTag;
     };

--- a/test/app/scripts/routes.js
+++ b/test/app/scripts/routes.js
@@ -18,6 +18,14 @@ export default {
   '/debug/redirect': {
     tag: 'page-debug-redirect',
   },
+  // URL は変えずタグだけリダイレクトさせる
+  '/debug/tagredirect': {
+    tag: async ({req, res}) => {
+      // ここで db の存在チェックとかしてなければ 404 に飛ばす
+      res.status(404);
+      return 'page-error';
+    },
+  },
 
 };
 


### PR DESCRIPTION
routes.js で

```
  // URL は変えずタグだけリダイレクトさせる
  '/debug/tagredirect': {
    tag: async ({req, res}) => {
      // ここで db の存在チェックとかしてなければ 404 に飛ばす
      res.status(404);
      return 'page-error';
    },
```

って感じでどのタグにするか動的に変更できるようにした.
req に useragent 入ってるから, pc のとき sp のときでタグ自体を入れ替えたりもできるようになるb