### PR TITLE
preload や head でエラーが出たら page-error に飛ばしてエラー内容を表示するよう修正

### DIFF
--- a/src/tags/spat-app.pug
+++ b/src/tags/spat-app.pug
@@ -41,12 +41,23 @@ spat-app
       this.refs.pages.appendChild(element);
 
       // preload 実行
-      await this.preload(pageTag, req, res);
+      try {
+        await this.preload(pageTag, req, res);
 
-      // head 取得
-      this.head = this.getHead(pageTag);
+        // head 取得
+        this.head = this.getHead(pageTag);
 
-      this.pageTag = pageTag;
+        this.pageTag = pageTag;
+      }
+      catch (e) {
+        res.error = e;
+        // エラーが出たら page-error を表示する
+        await this.gotoPage({
+          tag: 'page-error',
+        }, req, res);
+
+        return ;
+      }
     };
 
     this.preload = async (tag, req, res) => {

--- a/test/app/tags/pages/page-error.pug
+++ b/test/app/tags/pages/page-error.pug
@@ -1,13 +1,20 @@
 page-error
   div.s-full.f.fh
-    div.text-center
-      h2.fs64 {statusCode}
-      div
+    div
+      h2.text-center.fs64.mb16 {statusCode || 999}
+      p.white-space-pre-wrap.mb16(if='{error}') {error.stack || error.toString()}
+      div.text-center
         a(href='/') to TOP
+
+  style(type='less').
+    :scope {
+      display: block;
+    }
 
   script.
     this.preload = ({req, res}) => {
       return {
+        error: res.error,
         statusCode: res.statusCode,
       };
     };

--- a/test/app/tags/pages/page-groups-single.pug
+++ b/test/app/tags/pages/page-groups-single.pug
@@ -30,6 +30,12 @@ page-groups-single
         }
       }
 
+      // 存在しなかったら 404 に飛ばす
+      if (!ss.exists) {
+        res.status(404);
+        throw 'そのページは存在しません';
+      }
+
       console.log('fromCache:', ss.metadata.fromCache);
       console.log('group name:', ss.data().title);
 


### PR DESCRIPTION
preload 内で

```
      // 存在しなかったら 404 に飛ばす
      if (!ss.exists) {
        res.status(404);
        throw 'そのページは存在しません';
      }
```

とかできるようになる