### PR TITLE
client 側の appTag を生成するタイミングを調整

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -26,7 +26,8 @@ router.use((req, res, next) => {
 import riot from 'riot'
 riot.util.tmpl.errorHandler = function() {};
 
-spat.start = () => {
+// 初期化
+spat.init = () => {
   var clientElement = document.createElement('div');
   clientElement.setAttribute('render', 'client');
   var appTag = riot.mount(clientElement, 'spat-app')[0];
@@ -51,7 +52,10 @@ spat.start = () => {
       tag: 'page-error',
     }, req, res);
   });
+};
 
+// スタート
+spat.start = () => {
   // ルーティング実行
   if (spat.config.spa !== false) {
     spat.router.start();
@@ -105,5 +109,7 @@ spat.goto = async (route, req, res) => {
     window.scroll(0, 0);
   }
 };
+
+spat.init();
 
 export default spat;

--- a/test/app/client.js
+++ b/test/app/client.js
@@ -1,11 +1,16 @@
 import client from '.spat/modules/client';
 
-client.start();
 
+var indicator = null;
 spat.appTag.on('pagechange', (e) => {
   console.log('pagechange', e);
+  indicator = spat.modal.indicator();
 });
 
 spat.appTag.on('pagechanged', (e) => {
   console.log('pagechanged', e);
+
+  indicator && indicator.close();
 });
+
+client.start();


### PR DESCRIPTION
start を init と start に分離
init 側で appTag を作るようにした上で, すでに init した上で返すよう対応