### PR TITLE
ページをキャッシュするよう修正

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -110,6 +110,13 @@ spat.goto = async (route, req, res) => {
   }
 };
 
+spat.showSSR = () => {
+  var $serverApp = document.querySelector('[data-is=spat-app][render=server]');
+  if (!$serverApp) return ;
+
+  $serverApp.style.opacity = '';
+};
+
 spat.init();
 
 export default spat;

--- a/src/ssriot.js
+++ b/src/ssriot.js
@@ -14,6 +14,8 @@ module.exports = class Ssriot {
     var element = document.createElement('div');
     element.setAttribute('render', 'server');
     element.setAttribute('data-is', 'spat-app');
+    // SSR レンダリング時は非表示にする(未ログイン時の表示とかがちらつくので)
+    element.setAttribute('style', 'opacity:0');
     
     this.tag = riot.mount(element)[0];
 

--- a/src/tags/spat-app.pug
+++ b/src/tags/spat-app.pug
@@ -15,6 +15,7 @@ spat-app
 
   script.
     this.title = 'Hello, spat with parcel!';
+    this.cachedPages = {};
 
     this.on('mount', async () => {
     });
@@ -24,6 +25,8 @@ spat-app
     this.gotoPage = async (route, req, res, ssr=true) => {
       // route からタグ名を取得
       var tagName = '';
+      var cached = false;
+
       if (typeof route.tag === 'function') {
         tagName = await route.tag({req, res})
       }
@@ -35,30 +38,41 @@ spat-app
       const prevPageTag = this.pageTag;
 
       if (spat.isBrowser && prevPageTag) {
-        prevPageTag.trigger('hide');
-        prevPageTag.unmount();
+        prevPageTag.trigger('hide', {
+          req, res,
+        });
+        this.cachedPages[this.pageTag.opts.cacheKey] = prevPageTag;
+        prevPageTag.root.style.display = 'none';
       }
-      this.refs.pages.innerHTML = '';
       
-      var element = document.createElement('div');
-      element.setAttribute('data-is', tagName);
-      element.setAttribute('class', 'spat-page');
-      var pageTag = riot.mount(element, tagName)[0];
+      if (this.cachedPages[req.url]) {
+        var pageTag = this.cachedPages[req.url];
+        var element = pageTag.root;
+        cached = true;
 
-      element.style.display = 'none';
-      this.refs.pages.appendChild(element);
+        element.style.display = '';
+      }
+      else {
+        var element = document.createElement('div');
+        element.setAttribute('data-is', tagName);
+        element.setAttribute('class', 'spat-page');
+        element.setAttribute('cache-key', req.url);
+        var pageTag = riot.mount(element, tagName)[0];
+        this.refs.pages.appendChild(element);
+      }
 
       // preload 実行
       try {
         // ssr が true のときのみ preload を実行
         if (ssr) {
-          await this.preload(pageTag, req, res);
+          await this.preload(pageTag, {
+            req, res, cached,
+          });
         }
         // head 取得
         this.head = this.getHead(pageTag);
         this.pageTag = pageTag;
 
-        element.style.display = '';
         this.trigger('pagechanged', {prevPageTag});
       }
       catch (e) {
@@ -75,14 +89,16 @@ spat-app
       }
 
       if (spat.isBrowser) {
-        pageTag.trigger('show');
+        pageTag.trigger('show', {
+          req, res, cached
+        });
         pageTag.update();
       }
     };
 
-    this.preload = async (tag, req, res) => {
+    this.preload = async (tag, opts) => {
       if (tag.preload) {
-        var data = await tag.preload({req, res});
+        var data = await tag.preload(opts);
         Object.assign(tag, data);
         tag.update();
       }
@@ -95,7 +111,7 @@ spat-app
 
       // preload する
       var promises = tags.map(async (tag) => {
-        return this.preload(tag, req, res);
+        return this.preload(tag, opts);
       });
 
       await Promise.all(promises);

--- a/test/app/client.js
+++ b/test/app/client.js
@@ -13,4 +13,6 @@ spat.appTag.on('pagechanged', (e) => {
   indicator && indicator.close();
 });
 
+// client.showSSR();
+
 client.start();

--- a/test/app/tags/pages/page-index.pug
+++ b/test/app/tags/pages/page-index.pug
@@ -1,6 +1,7 @@
 page-index
   div
     div.sticky.t0.z100(data-is='module-header')
+
     div.container.p16
       h1.mb16 {title}
 

--- a/test/app/tags/pages/page-index.pug
+++ b/test/app/tags/pages/page-index.pug
@@ -1,11 +1,12 @@
 page-index
-  div.container
+  div
     div.sticky.t0.z100(data-is='module-header')
-    h1 {title}
+    div.container.p16
+      h1.mb16 {title}
 
-    div.my8
-      div
-        div.mb1(each='{item in items}', data-is='item-group', item='{item}')
+      div.my8
+        div
+          div.mb1(each='{item in items}', data-is='item-group', item='{item}')
 
   style(type='less').
     :scope {
@@ -15,7 +16,10 @@ page-index
   script.
     this.title = 'Hello, spat with parcel!';
 
-    this.preload = async ({req, res}) => {
+    this.preload = async ({req, res, cached}) => {
+      if (cached) return ;
+
+      console.log('index: preload');
       var ref = db.collection('groups');
       var ss = await ref.get({source: "cache"});
       
@@ -30,6 +34,8 @@ page-index
           data: doc.data(),
         }
       });
+
+      items = [...items, ...items, ...items];
 
       return {
         items,


### PR DESCRIPTION
一度レンダリングしたページは裏側でキャッシュするよう修正

## 確認方法

- test プロジェクトを起動
- ページをスクロール
- リンクをクリック
- 戻る
- スクロール位置が保持されている