### PR TITLE
ブラウザバックのとき必ずスクロール位置が保持されるよう対応

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -65,7 +65,7 @@ spat.start = () => {
 };
 
 spat.goto = async (route, req, res) => {
-  await spat.appTag.navTag.goto({route, req, res});
+  var result = await spat.appTag.navTag.goto({route, req, res});
 
   // meta の設定
   var head = spat.appTag.navTag.getHead();
@@ -102,8 +102,11 @@ spat.goto = async (route, req, res) => {
   }
   // 初回以外
   else {
-    // 一番上にスクロール
-    window.scroll(0, 0);
+    // キャッシュされていないページだった場合は上部にスクロール
+    if (result.cached === false) {
+      // 一番上にスクロール
+      window.scroll(0, 0);
+    }
   }
 };
 

--- a/src/tags/spat-nav.pug
+++ b/src/tags/spat-nav.pug
@@ -78,7 +78,6 @@ spat-nav
         // 非同期処理終了後に, 別のページになっていた場合は非表示に戻す(すぐにスワイプバックされたとき等)
         else {
           // TODO: hide も実行する
-
           currentPageTag.root.style.display = 'none';
         }
       }
@@ -109,6 +108,10 @@ spat-nav
       if (spat.isBrowser && tempPageTag) {
         this.cachePageTag(tempPageTag);
       }
+
+      return {
+        cached,
+      };
     };
 
     // ページタグをキャッシュ


### PR DESCRIPTION
初レンダリングされたタグのときだけ上部にスクロールすればうまくいくってことに気づいた