### PR TITLE
popstate 経由かどうかに応じて画面上部にスクロールさせるかを分岐

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -65,6 +65,9 @@ spat.start = () => {
 };
 
 spat.goto = async (route, req, res) => {
+  // 進む/戻る 経由かどうかのフラグを持っておく
+  var isPopState = spat.router.isPopState;
+
   var result = await spat.appTag.navTag.goto({route, req, res});
 
   // meta の設定
@@ -102,8 +105,8 @@ spat.goto = async (route, req, res) => {
   }
   // 初回以外
   else {
-    // キャッシュされていないページだった場合は上部にスクロール
-    if (result.cached === false) {
+    // 進む/戻る じゃなければ上部にスクロールする
+    if (isPopState !== true) {
       // 一番上にスクロール
       window.scroll(0, 0);
     }

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -222,7 +222,11 @@ class Router {
       return ;
     }
 
+    this.isPopState = true;
+
     this.exec();
+
+    this.isPopState = false;
   }
 }
 


### PR DESCRIPTION
ブラウザバック/フォワードだけではなく, リンクをクリックして遷移したときもスクロール位置が保存されちゃう問題があったので, 結局無理くりフラグをもたせて判定するよう修正しました.

## flow

- 通常リンク時
  + popstate を通らず spa 遷移するので isPopState が false
  + 一番上にスクロールする
- ブラウザバック/フォワード時
  + popstate を通るので isPopState が true
  + スクロールしない
  + isPopState を false に戻す
