### PR TITLE
キャッシュするタイミングを調整 & エラー時はキャッシュしないよう修正

### DIFF
--- a/src/tags/spat-nav.pug
+++ b/src/tags/spat-nav.pug
@@ -74,6 +74,11 @@ spat-nav
           // head 設定
           this._head = this.setupHead(currentPageTag);
           this.trigger('pagechanged', {});
+
+          // 最後にキャッシュする(エラーページ以外)
+          if (spat.isBrowser && !res.error) {
+            this.cachePageTag(this.currentPageTag);
+          }
         }
         // 非同期処理終了後に, 別のページになっていた場合は非表示に戻す(すぐにスワイプバックされたとき等)
         else {

--- a/src/tags/spat-nav.pug
+++ b/src/tags/spat-nav.pug
@@ -37,7 +37,8 @@ spat-nav
         tempPageTag.root.style.display = 'none';
       }
 
-      var currentPageTag = this.getCachedPage(req.url);
+      // エラーじゃないときのみキャッシュからの取得を試みる
+      var currentPageTag = !res.error ? this.getCachedPage(req.url) : null;
 
       if (currentPageTag) {
         currentPageTag.root.style.display = '';

--- a/src/tags/spat-nav.pug
+++ b/src/tags/spat-nav.pug
@@ -109,11 +109,6 @@ spat-nav
         this.currentPageTag.update();
       }
 
-      // 最後にキャッシュする
-      if (spat.isBrowser && tempPageTag) {
-        this.cachePageTag(tempPageTag);
-      }
-
       return {
         cached,
       };


### PR DESCRIPTION
ログインエラー画面 -> ログイン -> ログインエラー画面 に遷移すると無限ループになる問題対策
res.error があるときはキャッシュしないようにした