### PR TITLE
modal-alertのテキストをword-break-wordにする

### DIFF
--- a/src/tags/spat-modal.pug
+++ b/src/tags/spat-modal.pug
@@ -235,7 +235,7 @@ spat-modal-alert.f.fh(spat-animation='push')
   div.rounded-8(ref='modal')
     div.p16.border
       div.bold.fs16.text-center.mb8(if='{opts.title}') {opts.title}
-      p.text-center.white-space-pre-wrap.word-break-all {opts.message}
+      p.text-center.white-space-pre-wrap.word-break-word {opts.message}
     div.w-full.h44
       button.s-full(onclick='{close}') OK
 


### PR DESCRIPTION
## 概要
- 英語のアラートの場合に改行箇所がおかしくなったので、word-break-allからword-break-wordに変更