### PR TITLE
beforeunload 実装

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -66,6 +66,10 @@ spat.init = () => {
     const { currentPageTag } = spat.appTag.navTag;
     if (currentPageTag) {
       currentPageTag.trigger('beforeunload', e);
+      // 一応 preventDefault しておく
+      if (e.returnValue) {
+        e.preventDefault();
+      }
     }
   });
 

--- a/src/client.js
+++ b/src/client.js
@@ -62,21 +62,19 @@ spat.init = () => {
 
   // 画面遷移対応
   window.addEventListener('beforeunload', (e) => {
-    var currentPageTag = spat.appTag.navTag.currentPageTag;
-    if (currentPageTag && currentPageTag.beforeunload) {
-      var result = currentPageTag.beforeunload();
-
-      if (!result) {
-        e.returnValue = '行った変更が保存されない可能性があります。';
-        e.preventDefault();
-      }
+    // TODO: modal のチェック
+    const { currentPageTag } = spat.appTag.navTag;
+    if (currentPageTag) {
+      currentPageTag.trigger('beforeunload', e);
     }
   });
 
   router.addListener('beforeunload', (e) => {
     // TODO: modal のチェック
     const { currentPageTag } = spat.appTag.navTag;
-    currentPageTag.trigger('beforeunload', e);
+    if (currentPageTag) {
+      currentPageTag.trigger('beforeunload', e);
+    }
   });
 };
 

--- a/src/client.js
+++ b/src/client.js
@@ -72,6 +72,12 @@ spat.init = () => {
       }
     }
   });
+
+  router.addListener('beforeunload', (e) => {
+    // TODO: modal のチェック
+    const { currentPageTag } = spat.appTag.navTag;
+    currentPageTag.trigger('beforeunload', e);
+  });
 };
 
 // スタート

--- a/src/client.js
+++ b/src/client.js
@@ -60,21 +60,40 @@ spat.init = () => {
     }, req, res);
   });
 
+  // 戻るを押した際の挙動
+  // TODO: 進むのときは何もしないようにする
+  router.addListener('popstate', (e) => {
+    var modalTag = spat.modal.getCurrentModalTag();
+    if (modalTag) {
+      // モーダルを閉じる
+      modalTag.close();
+      // router 側でチェック
+      e.preventBack = true;
+    }
+  });
+
   // 画面遷移対応
   window.addEventListener('beforeunload', (e) => {
-    // TODO: modal のチェック
+    const modalTag = spat.modal.getCurrentModalTag();
+    if (modalTag) {
+      modalTag.trigger('beforeunload', e);
+    }
+    // modal があってもページの処理をする
     const { currentPageTag } = spat.appTag.navTag;
     if (currentPageTag) {
       currentPageTag.trigger('beforeunload', e);
-      // 一応 preventDefault しておく
-      if (e.returnValue) {
-        e.preventDefault();
-      }
+    }
+
+    // 一応 preventDefault しておく
+    if (e.returnValue) {
+      e.preventDefault();
     }
   });
 
   router.addListener('beforeunload', (e) => {
-    // TODO: modal のチェック
+    const modalTag = spat.modal.getCurrentModalTag();
+    // modal は popstate でやってるのでやらない
+    if (modalTag) return ;
     const { currentPageTag } = spat.appTag.navTag;
     if (currentPageTag) {
       currentPageTag.trigger('beforeunload', e);

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -65,7 +65,7 @@ class Router extends EventEmitter {
     this.isBack = false;
     this.isForward = false;
 
-    this.DEFAULT_BEFOREUNLOAD_MESSAGE = 'このサイトを離れますか？\n行った変更が保存されない可能性があります。';
+    this.DEFAULT_BEFOREUNLOAD_MESSAGE = 'このページを離れますか？\n行った変更が保存されない可能性があります。';
   }
 
   // history.state を安全な形に設定

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -267,12 +267,7 @@ class Router extends EventEmitter {
     }
 
     // state に pageIndex がなかった場合追加する
-    if (!_.isObject(history.state) || !Number.isInteger(history.state.pageIndex)) {
-      history.replaceState({
-        ...history.state,
-        pageIndex: 0,
-      }, '');
-    }
+    this.normalizeHistoryState();
 
     // 戻る/進む 判定
     this.isBack = this.pageIndex > history.state.pageIndex;

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -98,7 +98,7 @@ class Router extends EventEmitter {
   // 発火
   emit(path) {
     var url = URL.parse(path, true);
-
+    this.currentPath = path;
     // ヒットする Layer を検索して実行
     this._stack.some((layer) => {
       var params = layer.match(url);
@@ -285,6 +285,20 @@ class Router extends EventEmitter {
       this._skip = false;
       return ;
     }
+
+    // beforeunload
+    const canceled = this.dispatchBeforeunload();
+    if (canceled) {
+      this.normalizeHistoryState();
+      this.pageIndex = history.state.pageIndex + 1;
+      // URL をもとに戻す
+      history.pushState({
+        ...history.state,
+        pageIndex: this.pageIndex,
+      }, '', this.currentPath);
+      return ;
+    }
+
     // バックをキャンセル(modal 時を考慮)
     if (e.preventBack) {
       this._skip = true;

--- a/src/tags/spat-modal.pug
+++ b/src/tags/spat-modal.pug
@@ -179,9 +179,12 @@ spat-modal(show="{visible}")
 
     this.getCurrentModalTag = () => {
       var children = this.root.children;
-      var child = children[children.length-1];
-
-      return child && child._tag ? child._tag : null;
+      for (let i = children.length - 1; i >= 0; --i) {
+        var child = children[i];
+        if (child && child._tag) {
+          return child._tag;
+        }
+      }
     };
 
     this.alert = (message, title, options) => {

--- a/src/tags/spat-modal.pug
+++ b/src/tags/spat-modal.pug
@@ -181,7 +181,7 @@ spat-modal(show="{visible}")
       var children = this.root.children;
       for (let i = children.length - 1; i >= 0; --i) {
         var child = children[i];
-        if (child && child._tag) {
+        if (child && child._tag && !child._tag.isClose) {
           return child._tag;
         }
       }

--- a/src/tags/spat-modal.pug
+++ b/src/tags/spat-modal.pug
@@ -59,6 +59,8 @@ spat-modal(show="{visible}")
     }
   
   script.
+    this.DEFAULT_BEFOREUNLOAD_MESSAGE = 'この画面を閉じますか？\n行った変更が保存されない可能性があります。';
+
     this.on('mount', () => {
       if (spat.isBrowser) {
         // キーボードを押した際の挙動
@@ -74,19 +76,6 @@ spat-modal(show="{visible}")
             }
           }
         });
-
-        // 戻るを押した際の挙動
-        // TODO: 進むのときは何もしないようにする
-        window.addEventListener('popstate', (e) => {
-          var modalTag = this.getCurrentModalTag();
-
-          if (modalTag) {
-            // モーダルを閉じる
-            modalTag.close();
-            // router 側でチェック
-            e.preventBack = true;
-          }
-        }, false);
       }
     });
 
@@ -112,6 +101,21 @@ spat-modal(show="{visible}")
         modalTag.close = async () => {
           // close 中だったら何もしない
           if (modalTag.isClose) return ;
+
+          //- beforeunload
+          const event = { type: 'beforeunload' };
+          modalTag.trigger(event.type, event);
+          // returnValue がある場合は confirm を表示する
+          if (event.returnValue) {
+            let message = this.DEFAULT_BEFOREUNLOAD_MESSAGE;
+            if (typeof event.returnValue === 'string') {
+              message = event.returnValue;
+            }
+            // キャンセル時は何もしない
+            if (!await spat.modal.confirm(message)) {
+              return ;
+            }
+          }
 
           modalTag.isClose = true;
           var value = modalTag.value;

--- a/src/tags/spat-modal.pug
+++ b/src/tags/spat-modal.pug
@@ -65,11 +65,11 @@ spat-modal(show="{visible}")
         window.addEventListener('keydown', (e) => {
           // ESC
           if (e.keyCode === 27) {
-            e.preventDefault();
             var modalTag = this.getCurrentModalTag();
 
             // dismissible が true のモノのみ ESC で閉じれるようにする 
             if (modalTag && modalTag.opts.dismissible) {
+              e.preventDefault();
               modalTag.close();
             }
           }

--- a/test/app/tags/pages/page-debug.pug
+++ b/test/app/tags/pages/page-debug.pug
@@ -6,11 +6,11 @@ page-debug
       div.container
         div(data-is='module-header')
         //- h1 {title}
-
         div.mb16
           div isNode: {spat.isNode}
           div isBrowser: {spat.isBrowser}
-        
+        div.mb16
+          button.button(onclick='{openBeforeunloadTestModal}') beforeunload modal test
         div.mb16
           a.p8(href='/debug/redirect') リダイレクトへのリンク
 
@@ -60,3 +60,9 @@ page-debug
     this.on('beforeunload', e => {
       e.returnValue = 'beforeunload\n遷移しますか？';
     });
+    
+    this.openBeforeunloadTestModal = () => {
+      spat.modal.open('spat-modal-alert', {message: 'beforeunload test'}).on('beforeunload', e => {
+        e.returnValue = true;
+      });
+    };

--- a/test/app/tags/pages/page-debug.pug
+++ b/test/app/tags/pages/page-debug.pug
@@ -58,6 +58,5 @@ page-debug
     });
 
     this.on('beforeunload', e => {
-      console.log('asd')
-      e.returnValue = true;
+      e.returnValue = 'beforeunload\n遷移しますか？';
     });

--- a/test/app/tags/pages/page-debug.pug
+++ b/test/app/tags/pages/page-debug.pug
@@ -56,3 +56,8 @@ page-debug
 
     this.on('show', async () => {
     });
+
+    this.on('beforeunload', e => {
+      console.log('asd')
+      e.returnValue = true;
+    });

--- a/test/app/tags/pages/page-index.pug
+++ b/test/app/tags/pages/page-index.pug
@@ -49,10 +49,10 @@ page-index
       };
     };
 
-    this.beforeunload = () => {
-      return false;
-    };
-
+    this.on('beforeunload', e =>{
+      e.returnValue = true;
+    });
+    
     this.on('show', async () => {
       console.log('index: show');
     });

--- a/test/app/tags/pages/page-index.pug
+++ b/test/app/tags/pages/page-index.pug
@@ -49,10 +49,10 @@ page-index
       };
     };
 
-    this.on('beforeunload', e =>{
+    this.on('beforeunload', (e) => {
       e.returnValue = true;
     });
-    
+
     this.on('show', async () => {
       console.log('index: show');
     });


### PR DESCRIPTION
以下のタイミングで beforeunload に対応しました。
mobile safari では ブラウザ標準の beforeunload に対応してないので、究極的には編集内容は常にローカルストレージに保存する等の対応が必要になってきます。

- page 遷移全般
- spat.router.push, replace
- modal close
- modal でバック、ページ遷移
- タブを閉じる
