### PR TITLE
canonical対応

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -171,8 +171,9 @@ spat.updateMeta = () => {
         var $head = document.head;
         $head.appendChild($elm);
         // 属性情のkey, value 作る
-        var attribute_key = option.split('=')[0];   
-        var attribute_value = option.split('=')[1].slice(1, -1);   
+        var attributes = option.split('=');
+        var attribute_key = attributes[0];   
+        var attribute_value = attributes[1].slice(1, -1);   
         $elm.setAttribute(attribute_key, attribute_value);
       }
       $elm.setAttribute(item.key, item.value);

--- a/src/client.js
+++ b/src/client.js
@@ -165,7 +165,8 @@ spat.updateMeta = () => {
       if (!$elm) {
         var tag_name = item.query.split('[')[0];
         var option = item.query.split('[')[1].replace(']', '');
-        var $elm = document.createElement(tag_name);
+        $elm = document.createElement(tag_name);
+        // head内に置く
         var $head = document.getElementsByTagName('head')[0];
         $head.appendChild($elm);          
         $elm.setAttribute(option.split('=')[0], option.split('=')[1].replace(/"/g, ''));

--- a/src/client.js
+++ b/src/client.js
@@ -156,6 +156,7 @@ spat.updateMeta = () => {
     { query: 'meta[property="og:site_name"]', value: head.ogp.site_name },
     { query: 'meta[property="og:type"]', value: head.ogp.type },
     { query: 'meta[property="og:image"]', value: head.ogp.image },
+    { query: 'link[rel="canonical"]', value: head.canonical },
   ].forEach(item => {
     var $elm = document.querySelector(item.query);
     if ($elm) {

--- a/src/client.js
+++ b/src/client.js
@@ -167,7 +167,7 @@ spat.updateMeta = () => {
         var option = item.query.split('[')[1].replace(']', '');
         $elm = document.createElement(tag_name);
         // head内に置く
-        var $head = document.getElementsByTagName('head')[0];
+        var $head = document.head;
         $head.appendChild($elm);          
         $elm.setAttribute(option.split('=')[0], option.split('=')[1].replace(/"/g, ''));
       }

--- a/src/client.js
+++ b/src/client.js
@@ -149,23 +149,18 @@ spat.updateMeta = () => {
 
   // タイトル以外の設定
   [
-    { query: 'meta[name="description"]', value: head.description },
-    { query: 'meta[name="keywords"]', value: head.keywords },
-    { query: 'meta[property="og:title"]', value: head.ogp.title || head.title },
-    { query: 'meta[property="og:description"]', value: head.ogp.description || head.description },
-    { query: 'meta[property="og:site_name"]', value: head.ogp.site_name },
-    { query: 'meta[property="og:type"]', value: head.ogp.type },
-    { query: 'meta[property="og:image"]', value: head.ogp.image },
-    { query: 'link[rel="canonical"]', value: head.canonical },
+    { query: 'meta[name="description"]', key: 'content', value: head.description },
+    { query: 'meta[name="keywords"]', key: 'content', value: head.keywords },
+    { query: 'meta[property="og:title"]', key: 'content', value: head.ogp.title || head.title },
+    { query: 'meta[property="og:description"]', key: 'content', value: head.ogp.description || head.description },
+    { query: 'meta[property="og:site_name"]', key: 'content', value: head.ogp.site_name },
+    { query: 'meta[property="og:type"]', key: 'content', value: head.ogp.type },
+    { query: 'meta[property="og:image"]', key: 'content', value: head.ogp.image },
+    { query: 'link[rel="canonical"]', key: 'href', value: head.canonical },
   ].forEach(item => {
     var $elm = document.querySelector(item.query);
     if ($elm) {
-      if ($elm.tagName === 'LINK') {
-        $elm.setAttribute('href', item.value);
-      }
-      else {
-        $elm.setAttribute('content', item.value);
-      }
+      $elm.setAttribute(item.key, item.value);
     }
   });
 };

--- a/src/client.js
+++ b/src/client.js
@@ -160,7 +160,12 @@ spat.updateMeta = () => {
   ].forEach(item => {
     var $elm = document.querySelector(item.query);
     if ($elm) {
-      $elm.setAttribute('content', item.value);
+      if ($elm.tagName === 'LINK') {
+        $elm.setAttribute('href', item.value);
+      }
+      else {
+        $elm.setAttribute('content', item.value);
+      }
     }
   });
 };

--- a/src/client.js
+++ b/src/client.js
@@ -159,8 +159,24 @@ spat.updateMeta = () => {
     { query: 'link[rel="canonical"]', key: 'href', value: head.canonical },
   ].forEach(item => {
     var $elm = document.querySelector(item.query);
-    if ($elm) {
+    
+    if (item.value) {
+      // 要素がない場合は作る
+      if (!$elm) {
+        var tag_name = item.query.split('[')[0];
+        var option = item.query.split('[')[1].replace(']', '');
+        var $elm = document.createElement(tag_name);
+        var $head = document.getElementsByTagName('head')[0];
+        $head.appendChild($elm);          
+        $elm.setAttribute(option.split('=')[0], option.split('=')[1].replace(/"/g, ''));
+      }
       $elm.setAttribute(item.key, item.value);
+    }
+    else if (!item.value) {
+      // valueがなければ要素を削除
+      if ($elm) {
+        $elm.remove();
+      }
     }
   });
 };

--- a/src/client.js
+++ b/src/client.js
@@ -164,12 +164,16 @@ spat.updateMeta = () => {
       // 要素がない場合は作る
       if (!$elm) {
         var tag_name = item.query.split('[')[0];
-        var option = item.query.split('[')[1].replace(']', '');
+        // queryの[]で囲まれた部分を取得
+        var option = item.query.match(/\[.+?\]/)[0].slice(1, -1);
         $elm = document.createElement(tag_name);
         // head内に置く
         var $head = document.head;
-        $head.appendChild($elm);          
-        $elm.setAttribute(option.split('=')[0], option.split('=')[1].replace(/"/g, ''));
+        $head.appendChild($elm);
+        // 属性情のkey, value 作る
+        var attribute_key = option.split('=')[0];   
+        var attribute_value = option.split('=')[1].slice(1, -1);   
+        $elm.setAttribute(attribute_key, attribute_value);
       }
       $elm.setAttribute(item.key, item.value);
     }

--- a/src/client.js
+++ b/src/client.js
@@ -163,18 +163,20 @@ spat.updateMeta = () => {
     if (item.value) {
       // 要素がない場合は作る
       if (!$elm) {
+        // タグ名を取得
         var tag_name = item.query.split('[')[0];
-        // queryの[]で囲まれた部分を取得
-        var option = item.query.match(/\[.+?\]/)[0].slice(1, -1);
+        // 要素を作成
         $elm = document.createElement(tag_name);
-        // head内に置く
-        var $head = document.head;
-        $head.appendChild($elm);
-        // 属性情のkey, value 作る
-        var attributes = option.split('=');
-        var attribute_key = attributes[0];   
-        var attribute_value = attributes[1].slice(1, -1);   
+        // 属性を取得
+        // queryの[]で囲まれた部分を取得 (先頭文字から[までと 最後の]を削除)
+        var attribute_string = item.query.replace(/^.*?\[|\]$/g, '');
+        // 属性の情報を key と value に分解
+        var [attribute_key, attribute_value] = attribute_string.split('=');
+        var attribute_value = attribute_value.slice(1, -1);
+        // 属性をセット
         $elm.setAttribute(attribute_key, attribute_value);
+        // headタグの子要素に追加
+        document.head.appendChild($elm);
       }
       $elm.setAttribute(item.key, item.value);
     }

--- a/test/app/tags/pages/page-debug.pug
+++ b/test/app/tags/pages/page-debug.pug
@@ -65,10 +65,10 @@ page-debug
     this.head = () => {
       var meta = {
         'hoge': {
-          canonical: `hogehoge/hoge`,
+          canonical: `https://rabee.jp/`,
         },
         'fuga': {
-          canonical: `hogehoge/fuga`,
+          canonical: `https://rabee.jp/contact`,
         },
       }[this.id];
       return {

--- a/test/app/tags/pages/page-debug.pug
+++ b/test/app/tags/pages/page-debug.pug
@@ -39,6 +39,9 @@ page-debug
           ul.ml32
             li(each='{item in [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]}') item {item}
 
+      div.f.w-full.mb16
+        div.button.w-full(each='{button in buttons}', onclick='{onChangeTab}') {button.label}
+
     style(type='less').
       :scope {
         display: block;
@@ -46,13 +49,31 @@ page-debug
 
   script.
     this.title = 'Hello, spat with parcel!';
+    this.buttons = [
+      {label: 'hoge', id: 'hoge'},
+      {label: 'fuga', id: 'fuga'},
+    ];
 
     this.preload = async () => {
+      var id = 'fuga';
+
+      return {
+        id,
+      }
     };
 
     this.head = () => {
+      var meta = {
+        'hoge': {
+          canonical: `hogehoge/hoge`,
+        },
+        'fuga': {
+          canonical: `hogehoge/fuga`,
+        },
+      }[this.id];
       return {
         title: 'aaaaaaa',
+        canonical: meta.canonical,
       };
     };
 
@@ -73,4 +94,10 @@ page-debug
     this.testPageShowBug = () => {
       spat.router.push('/groups/LEzo4c4W2AvRsFL2M3lS');
       spat.router.push('/');
+    };
+
+    this.onChangeTab = (e) => {
+      this.id = e.item.button.id;
+      spat.updateMeta();
+      this.update();
     };

--- a/test/app/views/index.pug
+++ b/test/app/views/index.pug
@@ -9,6 +9,8 @@ html
     meta(name='keywords', content= head.keywords)
 
     link(rel='icon', href= head.favicon)
+    if (head.canonical)
+      link(rel='canonical', href= head.canonical)
 
     // ogp
     meta(property='og:title', content= head.ogp.title || head.title)


### PR DESCRIPTION
### 概要
- updateMetaでcanonicalも更新できる様にする
- canonicalがない場合[空文字やundefindとなるのが良くない](https://www.deepcrawl.jp/blog/best-practice/why-canonical-tags-are-essential/)ので、ない時は消す、ある時は作るといった処理も追加してます（他のmetaタグも同様）
- `/debug`ページ下部のボタンで検証可能

### 使う際のルール
- 元となるページには自分自身のurlを入れる
  - [上記についての記事](https://www.attend.jp/update_170825)
- urlはフルパスを入れる

### 検討中
- canonicalが必要ないページから必要なページに遷移すると動的につくられるがその位置がheadの最下部になる
- 色々な記事を参照した結果、headの中にあれば良いと言うのが大半だが稀にhead上部にあった方がいいとあるのでそこを対応するかどうか

### スクショ
![image](https://user-images.githubusercontent.com/56064608/127116097-1d336669-4d25-4588-9b1a-9ae002a35e25.png)

