### PR TITLE
preloadをキャッシュしてSSRで展開する対応

### DIFF
--- a/src/ssriot.js
+++ b/src/ssriot.js
@@ -19,7 +19,7 @@ module.exports = class Ssriot {
     
     this.tag = riot.mount(element)[0];
 
-    await this.tag.navTag.goto({route, req, res, ssr: isSsr});
+    await this.tag.navTag.goto({ route, req, res, ssr: isSsr });
 
     this.tagContent = sdom.serialize(this.tag.root);
   }
@@ -52,12 +52,22 @@ module.exports = class Ssriot {
 `;
   }
 
+  cacheScript() {
+    if (this.tag.navTag._preloadCache) {
+      return `spat._preload_cache = ${JSON.stringify(this.tag.navTag._preloadCache).replace(/<\/script/ig, '<\\/script')};`;
+    }
+    else {
+      return '';
+    }
+  }
+
   scripts() {
     return `
     <script>
     var spat = {};
     spat.config = ${JSON.stringify(spat.config)};
     spat.plugins = ${JSON.stringify(spat.plugins)};
+    ${this.cacheScript()}
     </script>
     <script src="/spat/modules.js" async></script>
 `;

--- a/src/tags/spat-nav.pug
+++ b/src/tags/spat-nav.pug
@@ -71,7 +71,7 @@ spat-nav
         if (ssr) {
           await this.preload(currentPageTag, {
             req, res, cached,
-          });
+          }, route.useServerSideData);
 
           // redirect がかかっていたら非表示にして以降をスキップ
           if (res.statusCode === 301 || res.statusCode === 302) {
@@ -136,9 +136,22 @@ spat-nav
     };
 
     // preload を再帰呼び出し
-    this.preload = async (tag, opts) => {
+    this.preload = async (tag, opts, preloadCache = false) => {
       if (tag.preload) {
-        var data = await tag.preload(opts);
+        var data;
+        //- SSR で展開したデータを入れる
+        if (preloadCache && spat.isBrowser && spat._preload_cache) {
+          data = spat._preload_cache;
+          //- 一回使ったら消す
+          delete spat._preload_cache;
+        }
+        else {
+          data = await tag.preload(opts);
+        }
+        //- SSR 時に展開するためのデータ
+        if (preloadCache && spat.isNode) {
+          this._preloadCache = data;
+        }
         Object.assign(tag, data);
         tag.update();
       }

--- a/test/app/scripts/routes.js
+++ b/test/app/scripts/routes.js
@@ -8,6 +8,7 @@ export default {
   },
   '/': {
     tag: 'page-index',
+    useServerSideData: true,
     // ssr: false,
   },
 

--- a/test/app/tags/items/item-group.pug
+++ b/test/app/tags/items/item-group.pug
@@ -1,5 +1,5 @@
 item-group
-  a.f.bg-white.p16(href='/{opts.item.ref.path}')
+  a.f.bg-white.p16(href='/{opts.item.path}')
     div.rect.w128.mr8
       img(src='{opts.item.data.image}')
     div {opts.item.data.title}

--- a/test/app/tags/pages/page-index.pug
+++ b/test/app/tags/pages/page-index.pug
@@ -31,11 +31,17 @@ page-index
       var items = ss.docs.map(doc => {
         return {
           id: doc.id,
-          ref: doc.ref,
+          path: doc.ref.path,
           data: doc.data(),
         }
       });
 
+      //- ref を消す
+      items.forEach((item) => {
+        delete item.data.user_ref;
+        delete item.data.users;
+        delete item.data.last_message_ref;
+      });
       items = [...items, ...items, ...items];
 
       return {


### PR DESCRIPTION
- routes.js で useServerSideData: true にするとpreloadで返した値を展開する
- client側でそれがあるときにpreloadを実行しないで代入する
- pageだけ対応