### PR TITLE
複数スラッシュのURLを単一スラッシュにリダイレクトさせる

### DIFF
--- a/src/server.mjs
+++ b/src/server.mjs
@@ -63,6 +63,18 @@ app.use((req, res, next) => {
   next();
 });
 
+// 複数スラッシュを単一スラッシュに置換する
+app.use((req, res, next) => {
+  var pathname = req.Url.pathname;
+  var normalizedPathname = pathname.replace(/\/\/+/g, '/');
+  if (pathname !== normalizedPathname) {
+    res.redirect(301, normalizedPathname + (req.Url.search || ''));
+  }
+  else {
+    next();
+  }
+});
+
 app.setup = function() {
   Object.keys(routes).forEach(key => {
   


### PR DESCRIPTION
`http://localhost:3000///abc///ddd` みたいなのを `http://localhost:3000/abc/ddd` にリダイレクト

search と hash が保持されることも確認済み