### PR TITLE
build のエラー時に終了コード1で終了するように修正

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -84,4 +84,8 @@ var main = async () => {
 };
 
 
-main();
+main().catch((e) => {
+  console.log(e);
+  console.error('エラーが発生しました。エラー内容を確認してください。');
+  process.exit(1);
+});

--- a/test/package.json
+++ b/test/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
-    "build": "set -eu; spat build; echo 'build complete'",
+    "build": "spat build && echo 'build complete'",
     "start": "spat start",
     "dev": "spat dev",
     "clean": "spat clean",

--- a/test/package.json
+++ b/test/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
-    "build": "spat build",
+    "build": "set -eu; spat build; echo 'build complete'",
     "start": "spat start",
     "dev": "spat dev",
     "clean": "spat clean",


### PR DESCRIPTION
test/app/plugins/firebase.js のどこかに `a ?? 1;` と書いて `npm run build` を実行
build complete が表示されなければ、意図通りに動作しています。